### PR TITLE
feat(foods): lean search responses and server-side paging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,6 +237,7 @@ Removed from the codebase. **Do not reintroduce** full-store spread wrappers; us
   - Online batch size: `80`
   - "Show more" increments visible rows and can trigger additional local DB page fetches.
 - Local DB paging in search mode uses `LOCAL_DB_QUERY_PAGE_SIZE = 500` with offset-based fetches when users load more.
+- **Online mode pages server-side too**: each fetch requests up to `ONLINE_SEARCH_PAGE_SIZE` (50, the RPC cap) and "Show more" appends the next page via `performOnlineSearch(query, { append: true })` with ID-dedupe. A request-id guard (`onlineSearchRequestIdRef`) drops stale responses so a slow earlier query can never overwrite newer results, and the paging cursor resets on query/mode changes.
 - Filter/result header intentionally shows **current loaded count only** in search mode (e.g. `240 foods found`) and updates as more rows are loaded.
 - Online mode remains debounced (`DEBOUNCE_DELAY = 500ms`) and enforces a minimum query length (`2` chars).
 - Long-press pinning is owned by `FoodSearchModal` UI interaction (`LONG_PRESS_DURATION = 650ms`) and persists through store `togglePinnedFood`.
@@ -933,7 +934,7 @@ Online text search and barcode lookup are split across two proxied services for 
 
 **Architecture:**
 - `services/foodCloud.js` — Client service for online text search (Supabase-backed curated catalog), with timeout + native base URL guard; maps canonical catalog rows to the app food shape.
-- `api/foods.js` — Vercel proxy for `action=search` over the Supabase PostgREST RPCs `search_foods` / `search_foods_total` (read-only **anon** key; RLS grants public SELECT + the RPCs are EXECUTE-granted to anon). Payload builders live in `api/foodRows.js` (canonical `catalogFoods` + synthetic FDC `foods` envelope for legacy native builds during the transition window).
+- `api/foods.js` — Vercel proxy for `action=search` over the Supabase PostgREST RPC `search_foods` (read-only **anon** key; RLS grants public SELECT + the RPCs are EXECUTE-granted to anon). Responses are **lean by default** — `{ catalogFoods, page }`; the legacy FDC `foods` envelope and the `search_foods_total` count RPC are only exercised when a caller opts in via `legacy=1` (or when served through `/api/usda`) so already-shipped native builds keep working while modern clients skip the duplicate payload + extra count call. Responses carry `Cache-Control: public, s-maxage=120, stale-while-revalidate=600`. Payload builders live in `api/foodRows.js` (canonical `catalogFoods` always, synthetic FDC `foods` envelope only on the legacy path).
 - `api/usda.js` — legacy alias of `api/foods.js` serving the old `/api/usda` URL so already-shipped builds keep working.
 - `services/openFoodFacts.js` — Client service for barcode lookups.
 - `api/openfoodfacts.js` — Vercel proxy supporting `action=barcode` (product lookup).
@@ -958,7 +959,9 @@ const results = await searchOnlineFoods('chicken breast', { page: 1, pageSize: 2
 const food = await searchBarcode('012345678901');
 ```
 
-Results are cached in `userData.cachedFoods` to reduce repeated network requests.
+Search results are cached at two layers:
+- **In-memory query-result cache** (`FOODS_SEARCH_CACHE_TTL_MS` = 5 min, `FOODS_SEARCH_CACHE_MAX_ENTRIES` = 64, LRU-recency-refreshed) inside `services/foodCloud.js` — dedupes identical query/page/size reads within a session (`clearFoodsSearchCache()` clears it and is used by tests).
+- **Persisted cache-on-select** in `userData.cachedFoods` — only foods the user actually selects/logs survive across sessions.
 
 **Rename scope:** the online path is branded "online database / food cloud" end-to-end: `/api/foods` (+ legacy `/api/usda` alias), `VITE_FOODS_API_BASE`, `services/foodCloud.js`, `api/foodRows.js`, and the internal RAG pipeline is now cloud-native (`FOOD_SEARCH_SOURCE.CLOUD` = `'cloud'`, `cloud_search_failed`/`cloud_search_aborted`, `try_cloud`, `cloud_*` decision/telemetry keys, `defaultSource: 'cloud'`). Two deliberate exceptions stay USDA-encoded: the persisted `usda_<fdcId>` food-id prefix (data provenance; backs stored favourites/pins) and the `'usda'` nutrient-invariant scope in `constants/nutrients/nutrients.js` (US "carb by difference" semantics — a different domain, not the search source).
 

--- a/api/foodRows.js
+++ b/api/foodRows.js
@@ -1,11 +1,14 @@
 // Payload builders for the /api/foods gateway (legacy /api/usda alias shares it).
 //
 // The proxy now serves the curated Supabase catalog instead of FoodData
-// Central. Two envelopes are emitted per search:
-//   - `catalogFoods`: the canonical per-100g row shape (new clients)
+// Central. Two envelopes exist, but only the canonical one is emitted by
+// default:
+//   - `catalogFoods`: the canonical per-100g row shape (new clients) — always
 //   - `foods`:        a synthetic FDC envelope so already-shipped native
 //                     builds still running the old FDC mapper keep working
-//                     during the transition window (grace period only)
+//                     during the transition window (grace period only); only
+//                     emitted when the caller opts in via `legacy=1` or the
+//                     /api/usda route
 //
 // Keep this module dependency-free and pure so it stays unit-testable under
 // `node --test` (see tests/api/usdaRows.test.js).

--- a/api/foods.js
+++ b/api/foods.js
@@ -8,7 +8,10 @@
 // writes are service-role only, via the pipeline seeder.
 //
 // Response envelope (see api/foodRows.js):
-//   { catalogFoods: [canonical rows…], foods: [legacy FDC rows…], totalHits, page }
+//   Lean default:  { catalogFoods: [canonical rows…], page }
+//   Legacy opt-in: { catalogFoods, foods: [legacy FDC rows…], totalHits, page }
+//     (enabled via `legacy=1` or when served through the /api/usda route so
+//     already-shipped native builds keep their FDC envelope + real totalHits)
 
 import { toCatalogPayloadRows, toLegacyFdcRows } from './foodRows.js';
 
@@ -134,6 +137,12 @@ export default async function handler(req, res) {
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
   res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  // Read-only search results over a rarely-changing catalog are safe to cache
+  // at the CDN/edge layer for a short window (Vercel s-maxage semantics).
+  res.setHeader(
+    'Cache-Control',
+    'public, s-maxage=120, stale-while-revalidate=600'
+  );
 
   if (req.method === 'OPTIONS') {
     return res.status(200).end();
@@ -156,7 +165,16 @@ export default async function handler(req, res) {
     });
   }
 
-  const { action, query, page, pageSize } = req.query;
+  const { action, query, page, pageSize, legacy } = req.query;
+  // The legacy FDC envelope + real totalHits are opt-in: only already-shipped
+  // native builds (via `legacy=1` or the /api/usda route) still need them, so
+  // modern clients skip the duplicate payload and the extra count RPC.
+  const wantsLegacyEnvelope =
+    String(legacy) === '1' ||
+    String(legacy).toLowerCase() === 'true' ||
+    String(req.url || '')
+      .split('?')[0]
+      .endsWith('/api/usda');
   const normalizedAction = String(action || 'search').toLowerCase();
 
   if (normalizedAction !== 'search') {
@@ -191,16 +209,21 @@ export default async function handler(req, res) {
       supabaseUrl,
       apiKey
     );
-    const totalHits =
-      (await searchCatalogTotal(normalizedQuery, supabaseUrl, apiKey)) ??
-      rows.length;
 
-    return res.status(200).json({
+    const payload = {
       catalogFoods: toCatalogPayloadRows(rows),
-      foods: toLegacyFdcRows(rows),
-      totalHits,
       page: safePage,
-    });
+    };
+
+    if (wantsLegacyEnvelope) {
+      const totalHits =
+        (await searchCatalogTotal(normalizedQuery, supabaseUrl, apiKey)) ??
+        rows.length;
+      payload.foods = toLegacyFdcRows(rows);
+      payload.totalHits = totalHits;
+    }
+
+    return res.status(200).json(payload);
   } catch (error) {
     console.error('food search proxy error:', error);
     return res.status(error?.status || 500).json({

--- a/api/openrouter.js
+++ b/api/openrouter.js
@@ -59,6 +59,7 @@ Conservative estimation policy (HIGH PRIORITY):
   - Keep assumptions explicit and brief.
 - Never invent foods, side items, toppings, or beverages not explicitly mentioned or visually evident.
 - For entries, include practical lookupTerms that improve local/USDA matching (food name, key descriptor, and brand when clearly provided).
+- Lookup terms must be whole words — the online catalog matches word prefixes, so "chicken" matches "chicken breast" but a mid-word fragment like "chic" will not. Split compound phrases into individual whole words.
 - Prefer canonical food names in "name" for lookup stability (brand can still be included in lookupTerms).
 - If multiple plausible interpretations exist, either:
   1) ask one concise follow-up question (preferred for low confidence), or

--- a/src/components/EnergyMap/modals/fullscreen/FoodSearchModal.jsx
+++ b/src/components/EnergyMap/modals/fullscreen/FoodSearchModal.jsx
@@ -86,6 +86,7 @@ const DEFAULT_MAX_IMAGE_COUNT = 3;
 const LOCAL_RESULT_BATCH_SIZE = 120;
 const ONLINE_RESULT_BATCH_SIZE = 80;
 const LOCAL_DB_QUERY_PAGE_SIZE = 500;
+const ONLINE_SEARCH_PAGE_SIZE = 50; // Supabase search RPC caps pageSize at 50
 const PANEL_EASE = [0.32, 0.72, 0, 1];
 const CHAT_REQUEST_STAGE = CHAT_PIPELINE_STAGE;
 const FOOD_SEARCH_DEFAULT_ENTRY_SET = new Set([
@@ -457,6 +458,8 @@ export const FoodSearchModal = ({
   );
   const [searchFallbackUsed, setSearchFallbackUsed] = useState(false);
   const [, setSearchErrorsBySource] = useState({});
+  const [hasMoreOnlineResults, setHasMoreOnlineResults] = useState(false);
+  const [isOnlineLoadingMore, setIsOnlineLoadingMore] = useState(false);
   const [loadingFoodId, setLoadingFoodId] = useState(null);
   const [localDbResults, setLocalDbResults] = useState([]);
   const [isLocalSearching, setIsLocalSearching] = useState(false);
@@ -481,6 +484,8 @@ export const FoodSearchModal = ({
   const searchTimeoutRef = useRef(null);
   const abortControllerRef = useRef(null);
   const hasAppliedDefaultEntryRef = useRef(false);
+  const onlineSearchRequestIdRef = useRef(0);
+  const onlinePageRef = useRef(0);
 
   // Network status
   const { isOnline } = useNetworkStatus();
@@ -941,47 +946,96 @@ export const FoodSearchModal = ({
     }
   }, [isManualAddConfirmClosing, isManualAddConfirmOpen]);
 
-  // Debounced online search
+  // Debounced online search. `append` fetches the next server page and appends
+  // it to the existing results; a request-id guard drops stale responses so a
+  // slow earlier query can never overwrite a newer one.
   const performOnlineSearch = useCallback(
-    async (query) => {
+    async (query, { append = false } = {}) => {
       if (!query || query.trim().length < 2) {
+        onlineSearchRequestIdRef.current += 1;
+        onlinePageRef.current = 0;
         setOnlineResults([]);
         setIsSearching(false);
+        setIsOnlineLoadingMore(false);
         setSearchFallbackUsed(false);
         setSearchErrorsBySource({});
         setActiveSearchSource(FOOD_SEARCH_SOURCE.CLOUD);
+        setHasMoreOnlineResults(false);
         return;
       }
 
       if (!isOnline) {
-        setOnlineResults([]);
+        onlineSearchRequestIdRef.current += 1;
+        if (!append) {
+          setOnlineResults([]);
+        }
         setSearchError('You are offline. Connect to search online foods.');
         setIsSearching(false);
+        setIsOnlineLoadingMore(false);
+        setHasMoreOnlineResults(false);
         return;
       }
 
-      setIsSearching(true);
+      const requestId = onlineSearchRequestIdRef.current + 1;
+      onlineSearchRequestIdRef.current = requestId;
+      const page = append ? Math.max(onlinePageRef.current + 1, 1) : 1;
+
+      if (append) {
+        setIsOnlineLoadingMore(true);
+      } else {
+        setIsSearching(true);
+        setIsOnlineLoadingMore(false);
+        setHasMoreOnlineResults(false);
+      }
       setSearchError(null);
+
       try {
         const result = await searchFoodsOnline({
           query,
+          onlinePage: page,
+          onlinePageSize: ONLINE_SEARCH_PAGE_SIZE,
         });
+
+        if (requestId !== onlineSearchRequestIdRef.current) {
+          return;
+        }
 
         const safeResults = Array.isArray(result?.results)
           ? result.results
           : [];
 
-        setOnlineResults(safeResults);
+        setOnlineResults((prev) => {
+          if (!append) {
+            return safeResults;
+          }
+          const seenIds = new Set(
+            prev.map((food) => food?.id).filter((id) => Boolean(id))
+          );
+          return [
+            ...prev,
+            ...safeResults.filter((food) => !seenIds.has(food?.id)),
+          ];
+        });
+        onlinePageRef.current = page;
+        setHasMoreOnlineResults(safeResults.length >= ONLINE_SEARCH_PAGE_SIZE);
         setActiveSearchSource(result?.source || FOOD_SEARCH_SOURCE.CLOUD);
         setSearchFallbackUsed(Boolean(result?.fallbackUsed));
         setSearchErrorsBySource(result?.errorsBySource || {});
         setSearchError(resolveSourceSearchError(result?.errorsBySource));
       } catch (error) {
+        if (requestId !== onlineSearchRequestIdRef.current) {
+          return;
+        }
         console.error('Online search error:', error);
         setSearchError(error?.message || 'Search failed. Please try again.');
-        setOnlineResults([]);
+        if (!append) {
+          setOnlineResults([]);
+        }
       } finally {
-        setIsSearching(false);
+        if (requestId === onlineSearchRequestIdRef.current) {
+          setIsSearching(false);
+          setIsOnlineLoadingMore(false);
+        }
       }
     },
     [isOnline, resolveSourceSearchError]
@@ -991,19 +1045,23 @@ export const FoodSearchModal = ({
   useEffect(() => {
     if (searchMode !== 'online') return;
 
+    // Invalidate any in-flight response for the previous query/window so it can
+    // never resolve into state after the query changed.
+    onlineSearchRequestIdRef.current += 1;
+    onlinePageRef.current = 0;
+
     // Clear previous timeout
     if (searchTimeoutRef.current) {
       clearTimeout(searchTimeoutRef.current);
     }
 
-    // Don't search if query too short
+    // Short queries clear through the same performOnlineSearch path — scheduled
+    // like the normal debounce so results, loading flags and the paging cursor
+    // reset consistently (and are cancelable by the effect cleanup).
     if (searchQuery.trim().length < 2) {
-      setOnlineResults([]);
-      setIsSearching(false);
-      setSearchError(null);
-      setSearchFallbackUsed(false);
-      setSearchErrorsBySource({});
-      setActiveSearchSource(FOOD_SEARCH_SOURCE.CLOUD);
+      searchTimeoutRef.current = setTimeout(() => {
+        performOnlineSearch(searchQuery);
+      }, 0);
       return;
     }
 
@@ -1021,6 +1079,14 @@ export const FoodSearchModal = ({
       }
     };
   }, [searchQuery, searchMode, performOnlineSearch]);
+
+  // When switching in/out of online mode, drop any in-flight online response
+  // and reset the paging cursor. Results/loading flags are reset by the next
+  // performOnlineSearch call (fresh query or short-query reset).
+  useEffect(() => {
+    onlineSearchRequestIdRef.current += 1;
+    onlinePageRef.current = 0;
+  }, [searchMode]);
 
   // Handle selecting an online food (cache and select)
   const handleOnlineFoodSelect = async (previewFood) => {
@@ -1815,7 +1881,8 @@ export const FoodSearchModal = ({
 
   const hasMoreResults =
     visibleResultCount < displayResults.length ||
-    (searchMode === 'local' && hasMoreLocalDbResults);
+    (searchMode === 'local' && hasMoreLocalDbResults) ||
+    (searchMode === 'online' && hasMoreOnlineResults);
 
   const handleLoadMoreResults = useCallback(() => {
     const batchSize =
@@ -1827,25 +1894,42 @@ export const FoodSearchModal = ({
       Math.min(current + batchSize, displayResults.length)
     );
 
+    if (!isOpen || viewMode !== 'search') {
+      return;
+    }
+
     if (
-      isOpen &&
-      viewMode === 'search' &&
       searchMode === 'local' &&
       !isLocalSearching &&
       !isLocalLoadingMore &&
       hasMoreLocalDbResults
     ) {
       runLocalSearch({ append: true, offset: localDbOffset });
+      return;
+    }
+
+    if (
+      searchMode === 'online' &&
+      !isSearching &&
+      !isOnlineLoadingMore &&
+      hasMoreOnlineResults
+    ) {
+      void performOnlineSearch(searchQuery, { append: true });
     }
   }, [
     displayResults.length,
     hasMoreLocalDbResults,
+    hasMoreOnlineResults,
     isLocalLoadingMore,
     isLocalSearching,
+    isOnlineLoadingMore,
     isOpen,
+    isSearching,
     localDbOffset,
+    performOnlineSearch,
     runLocalSearch,
     searchMode,
+    searchQuery,
     viewMode,
   ]);
 
@@ -3679,7 +3763,7 @@ export const FoodSearchModal = ({
                       <div className="pt-2 pb-1 flex justify-center">
                         <motion.button
                           onClick={handleLoadMoreResults}
-                          disabled={isLocalLoadingMore}
+                          disabled={isLocalLoadingMore || isOnlineLoadingMore}
                           initial={
                             prefersReducedMotion ? false : { opacity: 0, y: 6 }
                           }
@@ -3694,7 +3778,7 @@ export const FoodSearchModal = ({
                           }
                           className="px-4 py-2 rounded-lg border border-border bg-surface-highlight text-foreground text-sm font-medium md:hover:bg-surface pressable-card focus-ring"
                         >
-                          {isLocalLoadingMore
+                          {isLocalLoadingMore || isOnlineLoadingMore
                             ? 'Loading more...'
                             : `Show more (${visibleDisplayResults.length} loaded)`}
                         </motion.button>

--- a/src/services/foodCloud.js
+++ b/src/services/foodCloud.js
@@ -33,6 +33,53 @@ export const resetFoodsClientRetry = () => {
   Object.assign(FOODS_CLIENT_RETRY, FOODS_CLIENT_DEFAULT_RETRY);
 };
 
+// ---- in-memory query-result cache (TTL + LRU) ----
+//
+// Search results are repeatable reads over a rarely-changing catalog, so a
+// short-lived module cache avoids redundant network/DB work for identical
+// queries (typing patterns, repeated favourites lookups, paging back/forth).
+// Purged by TTL and capped by entry count; never persisted — the persisted
+// cache (cache-on-select) lives in `userData.cachedFoods`.
+
+export const FOODS_SEARCH_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+export const FOODS_SEARCH_CACHE_MAX_ENTRIES = 64;
+
+const foodsSearchCache = new Map(); // key -> { expiresAt, value }
+
+export const clearFoodsSearchCache = () => {
+  foodsSearchCache.clear();
+};
+
+export const getFoodsSearchCacheSize = () => foodsSearchCache.size;
+
+const readFoodsSearchCache = (key) => {
+  const entry = foodsSearchCache.get(key);
+  if (!entry) {
+    return null;
+  }
+  if (entry.expiresAt <= Date.now()) {
+    foodsSearchCache.delete(key);
+    return null;
+  }
+  // Refresh LRU recency on hit.
+  foodsSearchCache.delete(key);
+  foodsSearchCache.set(key, entry);
+  return entry.value;
+};
+
+const writeFoodsSearchCache = (key, value) => {
+  if (foodsSearchCache.size >= FOODS_SEARCH_CACHE_MAX_ENTRIES) {
+    const oldestKey = foodsSearchCache.keys().next().value;
+    if (oldestKey !== undefined) {
+      foodsSearchCache.delete(oldestKey);
+    }
+  }
+  foodsSearchCache.set(key, {
+    expiresAt: Date.now() + FOODS_SEARCH_CACHE_TTL_MS,
+    value,
+  });
+};
+
 // Kept identical to the legacy client set: transient 404/408/409/425/429 plus
 // 5xx and network failures (status 0) are retried. PostgREST 404 = misdeploy,
 // which a bounded retry masks harmlessly during rollouts.
@@ -287,6 +334,13 @@ export async function searchFoods(
     ? Math.min(Math.max(parsedPageSize, 1), 50)
     : 20;
 
+  const cacheKey = `${normalizedQuery}|${safePage}|${safePageSize}`;
+  const cached = readFoodsSearchCache(cacheKey);
+  if (cached) {
+    // Fresh copy so callers cannot mutate the shared cached result.
+    return { ...cached, foods: Array.from(cached.foods) };
+  }
+
   const data = await apiRequest(
     'search',
     {
@@ -314,9 +368,11 @@ export async function searchFoods(
     10
   );
 
-  return {
+  const result = {
     foods,
     totalResults: Number.isFinite(totalResults) ? totalResults : foods.length,
     page: safePage,
   };
+  writeFoodsSearchCache(cacheKey, result);
+  return result;
 }

--- a/tests/api/foods.contract.test.js
+++ b/tests/api/foods.contract.test.js
@@ -1,4 +1,5 @@
-﻿import test from 'node:test';
+/* eslint-disable no-undef -- process is a Node/Vercel Serverless global */
+import test from 'node:test';
 import assert from 'node:assert/strict';
 
 import handler from '../../api/foods.js';
@@ -83,13 +84,15 @@ const withFakeTimers = async (fn) => {
   }
 };
 
-test('proxy queries the Supabase search RPCs with service-role auth and returns both envelopes', async () => {
+test('proxy queries the search RPC with anon auth and returns the lean catalog envelope by default', async () => {
   const originalFetch = globalThis.fetch;
   let capturedUrl;
   let capturedHeaders;
+  let totalCalls = 0;
   globalThis.fetch = async (url, options) => {
     const parsed = new URL(url);
     if (parsed.pathname.endsWith('/search_foods_total')) {
+      totalCalls += 1;
       return createJsonFetchResponse({
         ok: true,
         status: 200,
@@ -117,6 +120,7 @@ test('proxy queries the Supabase search RPCs with service-role auth and returns 
         handler(
           {
             method: 'GET',
+            url: '/api/foods?action=search&query=chicken',
             query: {
               action: 'search',
               query: 'chicken',
@@ -141,16 +145,11 @@ test('proxy queries the Supabase search RPCs with service-role auth and returns 
       { id: 'p_100g', label: '100g', grams: 100 },
     ]);
 
-    // Legacy FDC envelope for old native builds.
-    assert.equal(response.jsonPayload.foods.length, 1);
-    assert.equal(response.jsonPayload.foods[0].fdcId, '171077');
-    assert.equal(
-      response.jsonPayload.foods[0].description,
-      'Chicken breast, raw'
-    );
-    assert.equal(response.jsonPayload.foods[0].servingSize, 100);
+    // Lean default: no legacy FDC envelope and no count RPC for modern clients.
+    assert.equal('foods' in response.jsonPayload, false);
+    assert.equal('totalHits' in response.jsonPayload, false);
+    assert.equal(totalCalls, 0);
 
-    assert.equal(response.jsonPayload.totalHits, 561);
     assert.equal(response.jsonPayload.page, 1);
 
     assert.equal(
@@ -162,6 +161,110 @@ test('proxy queries the Supabase search RPCs with service-role auth and returns 
     assert.equal(capturedUrl.searchParams.get('p_offset'), '0');
     assert.equal(capturedHeaders.apikey, 'anon-key');
     assert.equal(capturedHeaders.Authorization, 'Bearer anon-key');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('proxy includes the legacy FDC envelope + real totalHits when legacy=1', async () => {
+  const originalFetch = globalThis.fetch;
+  let totalCalls = 0;
+  globalThis.fetch = async (url) => {
+    const parsed = new URL(url);
+    if (parsed.pathname.endsWith('/search_foods_total')) {
+      totalCalls += 1;
+      return createJsonFetchResponse({
+        ok: true,
+        status: 200,
+        payload: 561,
+      });
+    }
+    return createJsonFetchResponse({
+      ok: true,
+      status: 200,
+      payload: [SAMPLE_ROW],
+    });
+  };
+
+  try {
+    const response = createResponse();
+    await withEnv(
+      {
+        SUPABASE_URL: 'https://proj.supabase.co',
+        SUPABASE_ANON_KEY: 'anon-key',
+      },
+      () =>
+        handler(
+          {
+            method: 'GET',
+            url: '/api/foods?action=search&query=chicken&legacy=1',
+            query: { action: 'search', query: 'chicken', legacy: '1' },
+            headers: {},
+          },
+          response
+        )
+    );
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.jsonPayload.catalogFoods.length, 1);
+
+    // Legacy FDC envelope for old native builds.
+    assert.equal(response.jsonPayload.foods.length, 1);
+    assert.equal(response.jsonPayload.foods[0].fdcId, '171077');
+    assert.equal(
+      response.jsonPayload.foods[0].description,
+      'Chicken breast, raw'
+    );
+    assert.equal(response.jsonPayload.foods[0].servingSize, 100);
+
+    assert.equal(response.jsonPayload.totalHits, 561);
+    assert.equal(response.jsonPayload.page, 1);
+    assert.equal(totalCalls, 1);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('proxy forces the legacy envelope on the /api/usda route', async () => {
+  const originalFetch = globalThis.fetch;
+  let totalCalls = 0;
+  globalThis.fetch = async (url) => {
+    const parsed = new URL(url);
+    if (parsed.pathname.endsWith('/search_foods_total')) {
+      totalCalls += 1;
+      return createJsonFetchResponse({ ok: true, status: 200, payload: 3 });
+    }
+    return createJsonFetchResponse({
+      ok: true,
+      status: 200,
+      payload: [SAMPLE_ROW],
+    });
+  };
+
+  try {
+    const response = createResponse();
+    await withEnv(
+      {
+        SUPABASE_URL: 'https://proj.supabase.co',
+        SUPABASE_ANON_KEY: 'anon-key',
+      },
+      () =>
+        handler(
+          {
+            method: 'GET',
+            url: '/api/usda?action=search&query=chicken',
+            query: { action: 'search', query: 'chicken' },
+            headers: {},
+          },
+          response
+        )
+    );
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.jsonPayload.catalogFoods.length, 1);
+    assert.equal(response.jsonPayload.foods.length, 1);
+    assert.equal(response.jsonPayload.totalHits, 3);
+    assert.equal(totalCalls, 1);
   } finally {
     globalThis.fetch = originalFetch;
   }
@@ -392,7 +495,7 @@ test('proxy does not retry non-transient upstream statuses', async () => {
   }
 });
 
-test('proxy degrades totalHits to rows.length when the count RPC fails', async () => {
+test('proxy degrades totalHits to rows.length when the count RPC fails (legacy path)', async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async (url) => {
     const parsed = new URL(url);
@@ -417,7 +520,8 @@ test('proxy degrades totalHits to rows.length when the count RPC fails', async (
         handler(
           {
             method: 'GET',
-            query: { action: 'search', query: 'chicken' },
+            query: { action: 'search', query: 'chicken', legacy: '1' },
+            url: '/api/foods?action=search&query=chicken&legacy=1',
             headers: {},
           },
           response
@@ -426,6 +530,7 @@ test('proxy degrades totalHits to rows.length when the count RPC fails', async (
 
     assert.equal(response.statusCode, 200);
     assert.equal(response.jsonPayload.catalogFoods.length, 2);
+    assert.equal(response.jsonPayload.foods.length, 2);
     assert.equal(response.jsonPayload.totalHits, 2);
   } finally {
     globalThis.fetch = originalFetch;

--- a/tests/services/foodCloud.test.js
+++ b/tests/services/foodCloud.test.js
@@ -1,4 +1,4 @@
-﻿import test from 'node:test';
+﻿import test, { beforeEach } from 'node:test';
 import assert from 'node:assert/strict';
 
 import {
@@ -6,8 +6,17 @@ import {
   resetFoodsClientRetry,
   searchFoods,
   FOODS_CLIENT_RETRY,
+  FOODS_SEARCH_CACHE_TTL_MS,
   FoodsApiError,
+  clearFoodsSearchCache,
+  getFoodsSearchCacheSize,
 } from '../../src/services/foodCloud.js';
+
+// The in-memory query-result cache is a session-level concern; every test
+// starts with an empty cache so tests keep their fetch-isolation contract.
+beforeEach(() => {
+  clearFoodsSearchCache();
+});
 
 const createJsonResponse = ({ ok, status, payload = {} }) => ({
   ok,
@@ -401,6 +410,124 @@ test('searchFoods respects the mutable FOODS_CLIENT_RETRY config', async () => {
     assert.equal(fetchCalls, 2);
   } finally {
     resetFoodsClientRetry();
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('searchFoods caches successful results per query/page and returns fresh copies', async () => {
+  clearFoodsSearchCache();
+  const originalFetch = globalThis.fetch;
+  let fetchCalls = 0;
+  globalThis.fetch = async () => {
+    fetchCalls += 1;
+    return createJsonResponse({
+      ok: true,
+      status: 200,
+      payload: { catalogFoods: [CHICKEN_ROW], page: 1 },
+    });
+  };
+
+  try {
+    const first = await searchFoods('chicken breast');
+    assert.equal(first.foods.length, 1);
+    assert.equal(first.page, 1);
+    assert.equal(fetchCalls, 1);
+
+    // Same query+page+pageSize hits the in-memory cache.
+    const second = await searchFoods('chicken breast');
+    assert.equal(second.foods.length, 1);
+    assert.equal(fetchCalls, 1);
+    assert.equal(getFoodsSearchCacheSize(), 1);
+
+    // Mutating a returned copy must never poison the shared cache entry.
+    second.foods.push({ id: 'injected' });
+    const third = await searchFoods('chicken breast');
+    assert.equal(third.foods.length, 1);
+
+    // A different page is a different cache key.
+    await searchFoods('chicken breast', { page: 2 });
+    assert.equal(fetchCalls, 2);
+
+    // A different query is a different cache key.
+    await searchFoods('pasta');
+    assert.equal(fetchCalls, 3);
+  } finally {
+    clearFoodsSearchCache();
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('searchFoods cache respects its TTL and clears on demand', async () => {
+  clearFoodsSearchCache();
+  const originalNow = Date.now;
+  const originalFetch = globalThis.fetch;
+  let fetchCalls = 0;
+  globalThis.fetch = async () => {
+    fetchCalls += 1;
+    return createJsonResponse({
+      ok: true,
+      status: 200,
+      payload: { catalogFoods: [CHICKEN_ROW], page: 1 },
+    });
+  };
+
+  try {
+    let now = 1_700_000_000_000;
+    Date.now = () => now;
+
+    await searchFoods('ttl egg');
+    assert.equal(fetchCalls, 1);
+
+    // Still fresh just before the TTL boundary.
+    now += FOODS_SEARCH_CACHE_TTL_MS - 1;
+    await searchFoods('ttl egg');
+    assert.equal(fetchCalls, 1);
+
+    // Past the TTL: the next read refetches.
+    now += 1_500;
+    await searchFoods('ttl egg');
+    assert.equal(fetchCalls, 2);
+
+    clearFoodsSearchCache();
+    assert.equal(getFoodsSearchCacheSize(), 0);
+    await searchFoods('ttl egg');
+    assert.equal(fetchCalls, 3);
+  } finally {
+    Date.now = originalNow;
+    clearFoodsSearchCache();
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('searchFoods does not cache aborted or failed requests', async () => {
+  clearFoodsSearchCache();
+  const originalFetch = globalThis.fetch;
+  let fetchCalls = 0;
+  const controller = new globalThis.AbortController();
+  globalThis.fetch = async () => {
+    fetchCalls += 1;
+    controller.abort();
+    const abortError = new Error('The operation was aborted.');
+    abortError.name = 'AbortError';
+    throw abortError;
+  };
+
+  try {
+    await assert.rejects(
+      searchFoods('aborted egg', {
+        signal: controller.signal,
+      }),
+      (error) => {
+        assert.ok(error instanceof FoodsApiError);
+        assert.equal(error.status, 0);
+        assert.equal(error.message, 'Request aborted');
+        return true;
+      }
+    );
+    assert.equal(fetchCalls, 1);
+    assert.equal(getFoodsSearchCacheSize(), 0);
+  } finally {
+    clearFoodsSearchCache();
     globalThis.fetch = originalFetch;
   }
 });


### PR DESCRIPTION
Default `/api/foods` search now returns only canonical catalogFoods with a page cursor; legacy FDC envelope and total count RPC are opt-in via legacy=1 for older builds. Online mode pages server-side with ID-dedupe and a request-id guard against stale overwrites, plus an LRU in-memory query cache and persisted cache-on-select.